### PR TITLE
allow the user to specify a full FMRI for a service

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -5,7 +5,9 @@ require 'builder'
 include Chef::Mixin::ShellOut
 
 def load_current_resource
-  find_fmri
+  if ! new_resource.fmri
+    find_fmri
+  end
 
   @current_resource = Chef::Resource::Smf.new(new_resource.name)
   @current_resource.fmri(new_resource.fmri)


### PR DESCRIPTION
If the user provides a fixed FMRI string in the smf resource, don't
try to find/create the right FMRI, just trust the user.
