### PR TITLE
equal_to arguments attribute stability should be an array

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -36,7 +36,7 @@ attribute :duration, kind_of: String, default: 'contract', regex: '(contract|wai
 attribute :ignore, kind_of: [Array, NilClass], default: nil
 attribute :fmri, kind_of: String, default: nil
 
-attribute :stability, kind_of: String, equal_to: %(Standard Stable Evolving Unstable External Obsolete),
+attribute :stability, kind_of: String, equal_to: %w(Standard Stable Evolving Unstable External Obsolete),
                       default: 'Evolving'
 
 attribute :property_groups, kind_of: Hash, default: {}


### PR DESCRIPTION
So basically I had this error 
<img width="1266" alt="screen shot 2016-02-15 at 3 33 17 pm" src="https://cloud.githubusercontent.com/assets/7490092/13045508/ab7acea6-d3f9-11e5-809b-100a33a47686.png">

So, %(abc def) will return a string "abc def", while %w(abc def) will result in ['abc', 'def']. Which should be the case. So just a pull request for that :) 
[https://github.com/livinginthepast/smf/issues/26](url)
